### PR TITLE
Add Node.js installation and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,39 @@ Eventually I came up with a small 'theory' of URLs that I found very helpful and
 [URL Specification]: https://alwinb.github.io/url-specification/#url-specification
 
 
+Installation
+---
+
+### Node.js
+
+```
+npm install reurl
+```
+
+### Standalone minified build
+
+```
+git clone https://github.com/alwinb/reurl.git
+cd reurl
+make all
+cp dist/reurl.min.js /my/project/js/
+```
+
+
 API
 ---
 
 ### Overview
 
 The ReUrl library exposes an Url class and a RawUrl class with an identical API. Their only difference is in their handling of percent escape sequences. 
+
+In a Node.JS project, you can use these classes as follows:
+
+```javascript
+import { Url, RawUrl } from 'reurl'
+```
+
+**Note:** ReUrl is an ESM-only module, so it cannot be imported with `require`.
 
 <details><summary>Url</summary>
 


### PR DESCRIPTION
Fixes #7 

I tested this change as follows:

1. `mkdir reurl-test && cd reurl-test`
2. `npm init`, accept all defaults
3. add `"type": "module",` to `package.json`
4. `npm install reurl`
5. write this script and run it:

**test.js**

```javascript
import { Url, RawUrl } from './lib/index.js'

console.log(Url)
console.log(RawUrl)
```

Result:

```
$ node test
[class Url]
[class RawUrl extends Url]
```
