### PR TITLE
Add CommonJS support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ sources = $(addprefix lib/, $(files))
 #run: all
 #	@ echo $(sources)
 
-all: dist/reurl.min.js
+all: dist/reurl.min.js dist/reurl.cjs dist/reurl.min.cjs
 
 test: test/run/urltestdata.json
 	@ echo ""
@@ -20,6 +20,18 @@ clean: testclean distclean
 dist/reurl.min.js: dist/ package.json $(sources)
 	@ echo "Making a minified ES module bundle"
 	@ esbuild --bundle  --format=esm --minify lib/index.js > dist/reurl.min.js
+
+## CommonJS bundle
+
+dist/reurl.cjs: dist/ package.json $(sources)
+	@ echo "Making a minified CommonJS bundle"
+	@ esbuild --bundle  --format=cjs lib/index.js > dist/reurl.cjs
+
+## CommonJS bundle (minified)
+
+dist/reurl.min.cjs: dist/ package.json $(sources)
+	@ echo "Making a minified CommonJS bundle"
+	@ esbuild --bundle  --format=cjs --minify lib/index.js > dist/reurl.min.cjs
 
 dist/:
 	@ mkdir dist/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ npm install reurl
 ```
 git clone https://github.com/alwinb/reurl.git
 cd reurl
-make all
+npm install    # install dependencies
+npm run build  # create minified builds in dist/
 cp dist/reurl.min.js /my/project/js/
 ```
 
@@ -53,11 +54,21 @@ The ReUrl library exposes an Url class and a RawUrl class with an identical API.
 
 In a Node.JS project, you can use these classes as follows:
 
+#### With `import` (for modern ESM modules)
+
 ```javascript
 import { Url, RawUrl } from 'reurl'
 ```
 
-**Note:** ReUrl is an ESM-only module, so it cannot be imported with `require`.
+#### With `require` (for legacy CommonJS modules)
+
+```javascript
+const Url = require('reurl').Url
+```
+
+```javascript
+const RawUrl = require('reurl').RawUrl
+```
 
 <details><summary>Url</summary>
 

--- a/README.md
+++ b/README.md
@@ -50,25 +50,7 @@ API
 
 ### Overview
 
-The ReUrl library exposes an Url class and a RawUrl class with an identical API. Their only difference is in their handling of percent escape sequences. 
-
-In a Node.JS project, you can use these classes as follows:
-
-#### With `import` (for modern ESM modules)
-
-```javascript
-import { Url, RawUrl } from 'reurl'
-```
-
-#### With `require` (for legacy CommonJS modules)
-
-```javascript
-const Url = require('reurl').Url
-```
-
-```javascript
-const RawUrl = require('reurl').RawUrl
-```
+The ReUrl library exposes an Url class and a RawUrl class with an identical API. Their only difference is in their handling of percent escape sequences.
 
 <details><summary>Url</summary>
 
@@ -97,6 +79,26 @@ url.toString () // => '//host/%61bc?%25%64ef'
 </details>
 
 Url and RawUrl objects are **immutable**. Modifying URLs is acomplished through methods that return new Url and/ or RawUrl objects, such as the **url.set (patch)** method described below. 
+
+### Usage
+
+In a Node.JS project, you can use the `Url` and `RawUrl` classes as follows:
+
+#### With `import` (for modern ESM modules)
+
+```javascript
+import { Url, RawUrl } from 'reurl'
+```
+
+#### With `require` (for legacy CommonJS modules)
+
+```javascript
+const Url = require('reurl').Url
+```
+
+```javascript
+const RawUrl = require('reurl').RawUrl
+```
 
 ### Constructors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,424 @@
+{
+  "name": "reurl",
+  "version": "1.0.0-rc.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "reurl",
+      "version": "1.0.0-rc.2",
+      "license": "MIT",
+      "dependencies": {
+        "spec-url": "^2.0.0-dev.1"
+      },
+      "devDependencies": {
+        "esbuild": "^0.18.6"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.6.tgz",
+      "integrity": "sha512-J3lwhDSXBBppSzm/LC1uZ8yKSIpExc+5T8MxrYD9KNVZG81FOAu2VF2gXi/6A/LwDDQQ+b6DpQbYlo3VwxFepQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.6.tgz",
+      "integrity": "sha512-pL0Ci8P9q1sWbtPx8CXbc8JvPvvYdJJQ+LO09PLFsbz3aYNdFBGWJjiHU+CaObO4Ames+GOFpXRAJZS2L3ZK/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.6.tgz",
+      "integrity": "sha512-hE2vZxOlJ05aY28lUpB0y0RokngtZtcUB+TVl9vnLEnY0z/8BicSvrkThg5/iI1rbf8TwXrbr2heEjl9fLf+EA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.6.tgz",
+      "integrity": "sha512-/tuyl4R+QhhoROQtuQj9E/yfJtZNdv2HKaHwYhhHGQDN1Teziem2Kh7BWQMumfiY7Lu9g5rO7scWdGE4OsQ6MQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.6.tgz",
+      "integrity": "sha512-L7IQga2pDT+14Ti8HZwsVfbCjuKP4U213T3tuPggOzyK/p4KaUJxQFXJgfUFHKzU0zOXx8QcYRYZf0hSQtppkw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.6.tgz",
+      "integrity": "sha512-bq10jFv42V20Kk77NvmO+WEZaLHBKuXcvEowixnBOMkaBgS7kQaqTc77ZJDbsUpXU3KKNLQFZctfaeINmeTsZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.6.tgz",
+      "integrity": "sha512-HbDLlkDZqUMBQaiday0pJzB6/8Xx/10dI3xRebJBReOEeDSeS+7GzTtW9h8ZnfB7/wBCqvtAjGtWQLTNPbR2+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.6.tgz",
+      "integrity": "sha512-C+5kb6rgsGMmvIdUI7v1PPgC98A6BMv233e97aXZ5AE03iMdlILFD/20HlHrOi0x2CzbspXn9HOnlE4/Ijn5Kw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.6.tgz",
+      "integrity": "sha512-NMY9yg/88MskEZH2s4i6biz/3av+M8xY5ua4HE7CCz5DBz542cr7REe317+v7oKjnYBCijHpkzo5vU85bkXQmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.6.tgz",
+      "integrity": "sha512-AXazA0ljvQEp7cA9jscABNXsjodKbEcqPcAE3rDzKN82Vb3lYOq6INd+HOCA7hk8IegEyHW4T72Z7QGIhyCQEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.6.tgz",
+      "integrity": "sha512-JjBf7TwY7ldcPgHYt9UcrjZB03+WZqg/jSwMAfzOzM5ZG+tu5umUqzy5ugH/crGI4eoDIhSOTDp1NL3Uo/05Fw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.6.tgz",
+      "integrity": "sha512-kATNsslryVxcH1sO3KP2nnyUWtZZVkgyhAUnyTVVa0OQQ9pmDRjTpHaE+2EQHoCM5wt/uav2edrAUqbwn3tkKQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.6.tgz",
+      "integrity": "sha512-B+wTKz+8pi7mcWXFQV0LA79dJ+qhiut5uK9q0omoKnq8yRIwQJwfg3/vclXoqqcX89Ri5Y5538V0Se2v5qlcLA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.6.tgz",
+      "integrity": "sha512-h44RBLVXFUSjvhOfseE+5UxQ/r9LVeqK2S8JziJKOm9W7SePYRPDyn7MhzhNCCFPkcjIy+soCxfhlJXHXXCR0A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.6.tgz",
+      "integrity": "sha512-FlYpyr2Xc2AUePoAbc84NRV+mj7xpsISeQ36HGf9etrY5rTBEA+IU9HzWVmw5mDFtC62EQxzkLRj8h5Hq85yOQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.6.tgz",
+      "integrity": "sha512-Mc4EUSYwzLci77u0Kao6ajB2WbTe5fNc7+lHwS3a+vJISC/oprwURezUYu1SdWAYoczbsyOvKAJwuNftoAdjjg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.6.tgz",
+      "integrity": "sha512-3hgZlp7NqIM5lNG3fpdhBI5rUnPmdahraSmwAi+YX/bp7iZ7mpTv2NkypGs/XngdMtpzljICxnUG3uPfqLFd3w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.6.tgz",
+      "integrity": "sha512-aEWTdZQHtSRROlDYn7ygB8yAqtnall/UnmoVIJVqccKitkAWVVSYocQUWrBOxLEFk8XdlRouVrLZe6WXszyviA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.6.tgz",
+      "integrity": "sha512-uxk/5yAGpjKZUHOECtI9W+9IcLjKj+2m0qf+RG7f7eRBHr8wP6wsr3XbNbgtOD1qSpPapd6R2ZfSeXTkCcAo5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.6.tgz",
+      "integrity": "sha512-oXlXGS9zvNCGoAT/tLHAsFKrIKye1JaIIP0anCdpaI+Dc10ftaNZcqfLzEwyhdzFAYInXYH4V7kEdH4hPyo9GA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.6.tgz",
+      "integrity": "sha512-qh7IcAHUvvmMBmoIG+V+BbE9ZWSR0ohF51e5g8JZvU08kZF58uDFL5tHs0eoYz31H6Finv17te3W3QB042GqVA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.6.tgz",
+      "integrity": "sha512-9UDwkz7Wlm4N9jnv+4NL7F8vxLhSZfEkRArz2gD33HesAFfMLGIGNVXRoIHtWNw8feKsnGly9Hq1EUuRkWl0zA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.6.tgz",
+      "integrity": "sha512-5QgxWaAhU/tPBpvkxUmnFv2YINHuZzjbk0LeUUnC2i3aJHjfi5yR49lgKgF7cb98bclOp/kans8M5TGbGFfJlQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.6",
+        "@esbuild/android-arm64": "0.18.6",
+        "@esbuild/android-x64": "0.18.6",
+        "@esbuild/darwin-arm64": "0.18.6",
+        "@esbuild/darwin-x64": "0.18.6",
+        "@esbuild/freebsd-arm64": "0.18.6",
+        "@esbuild/freebsd-x64": "0.18.6",
+        "@esbuild/linux-arm": "0.18.6",
+        "@esbuild/linux-arm64": "0.18.6",
+        "@esbuild/linux-ia32": "0.18.6",
+        "@esbuild/linux-loong64": "0.18.6",
+        "@esbuild/linux-mips64el": "0.18.6",
+        "@esbuild/linux-ppc64": "0.18.6",
+        "@esbuild/linux-riscv64": "0.18.6",
+        "@esbuild/linux-s390x": "0.18.6",
+        "@esbuild/linux-x64": "0.18.6",
+        "@esbuild/netbsd-x64": "0.18.6",
+        "@esbuild/openbsd-x64": "0.18.6",
+        "@esbuild/sunos-x64": "0.18.6",
+        "@esbuild/win32-arm64": "0.18.6",
+        "@esbuild/win32-ia32": "0.18.6",
+        "@esbuild/win32-x64": "0.18.6"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/spec-url": {
+      "version": "2.0.0-dev.1",
+      "resolved": "https://registry.npmjs.org/spec-url/-/spec-url-2.0.0-dev.1.tgz",
+      "integrity": "sha512-NKE2wT6tsvYa4xfVFcnjxSDFJwDOwU1NU2NhfnxFksutZrOShZ2p7pgQWS98Evq0cHMGBBjGQlbwrcAHLDywfw==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,16 @@
   "name": "reurl",
   "version": "1.0.0-rc.2",
   "description": "URL manipulation library",
-  "main": "lib/index.js",
+  "main": "./dist/reurl.cjs",
+  "module": "lib/index.js",
   "type": "module",
+  "exports": {
+    "import": "./lib/index.js",
+    "require": "./dist/reurl.cjs"
+  },
   "scripts": {
+    "build": "make",
+    "prepare": "npm run build",
     "test": "make test"
   },
   "repository": {
@@ -27,5 +34,8 @@
   "license": "MIT",
   "dependencies": {
     "spec-url": "^2.0.0-dev.1"
+  },
+  "devDependencies": {
+    "esbuild": "^0.18.6"
   }
 }


### PR DESCRIPTION
## Overview

This change allows consumers to import `reurl` using either `import` or `require`.

I added support for `require` because I want to use `reurl` in a legacy project that does not support ESM imports.

Feel free to take or leave this change. It does add more complexity and maintenance overhead so I completely understand if you'd rather keep `reurl` ESM-only. People can always make forks.

## Testing this change

1. Clone my test repo:

```
git clone https://github.com/jsepia/reurl-test.git
```

The test repo contains two files:

* `test.js` imports `reurl` using the `import` syntax
* `test.cjs` imports `reurl` using `require`

2. Run the test scripts:

```
# node v12
$ nvm use v12
Now using node v12.22.12 (npm v6.14.16)
```

```
$ npm run test:esm

> reurl-test2@1.0.0 test:esm /path/to/reurl-test2
> node --experimental-modules test.js

[class Url]
[class RawUrl extends Url]
$ npm run test:commonjs

> reurl-test2@1.0.0 test:commonjs /path/to/reurl-test2
> node test.cjs

{ RawUrl: [Getter], Url: [Getter], version: [Getter] }
[class _Url]
[class RawUrl extends _Url]
```